### PR TITLE
Thermal: Add make file for thermal host utility

### DIFF
--- a/vm_thermal_utility/Android.mk
+++ b/vm_thermal_utility/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := thermsys
+
+LOCAL_SRC_FILES := thermal_sysfsread.c
+
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
This patch adds Android makefile for thermal host
utility so that it can get built as part of target.

Tracked-On: OAM-91272
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>