### PR TITLE
Use clang from prebuilts instead of host gcc

### DIFF
--- a/vm_thermal_utility/Makefile
+++ b/vm_thermal_utility/Makefile
@@ -1,2 +1,2 @@
 thermmake: thermal_sysfsread.c
-	gcc -o thermsys thermal_sysfsread.c -I -Wall -Wpointer-sign -Wmaybe-uninitialized -Wuninitialized -Wunused-parameter
+	clang -o thermsys thermal_sysfsread.c -I -Wall -Wpointer-sign -Wuninitialized -Wunused-parameter


### PR DESCRIPTION
This is required to enable setup path restrictions
for Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>